### PR TITLE
pip install error and run in __init__.py

### DIFF
--- a/csv_overview/__init__.py
+++ b/csv_overview/__init__.py
@@ -83,7 +83,7 @@ def run(args):
 		print 'Usage:'
 		print '\tcsv-overview data.csv'
 	else:
-		run(args[1])
+		process(args[1])
 
 if __name__ == '__main__':
 	run(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='csv_overview',
       version='0.32',
       description='Get the vital statistics of a CSV file',
-      long_description=open('readme.md', 'rb').read(),
+      long_description=open('README.md', 'rb').read(),
       url='http://github.com/sbirch/csv-overview',
       classifiers=['License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
pip install csv_overview on ubuntu fails with this error:

```
long_description=open('readme.md', 'rb').read(),
IOError: [Errno 2] No such file or directory: 'readme.md'
```

This is due to case sensitivity.
